### PR TITLE
Added support for canceling a expand and reworked rotation

### DIFF
--- a/FloatingMenu/FloatingMenu/Controls/FloatingMenu.xaml
+++ b/FloatingMenu/FloatingMenu/Controls/FloatingMenu.xaml
@@ -3,10 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:FloatingMenu.Controls;assembly=FloatingMenu"
              x:Class="FloatingMenu.Controls.FloatingMenu"
-             Rotation="180"
              Margin="15, 10"
-             >
+>
 
-    <controls:FloatingButton x:Name="FloatingButton" Rotation="180" />
+    <controls:FloatingButton x:Name="FloatingButton" />
   
 </AbsoluteLayout>

--- a/FloatingMenu/FloatingMenu/Controls/FloatingMenu.xaml.cs
+++ b/FloatingMenu/FloatingMenu/Controls/FloatingMenu.xaml.cs
@@ -147,6 +147,7 @@ namespace FloatingMenu.Controls
             foreach (var (child, index) in Children.Select((c,i)=>(c,i)))
             {
                 child.Scale = 0.7;
+                child.Rotation = -Rotation;
                 SetLayoutBounds(child, new Rectangle(0, YAxis * index, MenuButtonWidth, MenuButtonHeight));
             }
 
@@ -158,12 +159,9 @@ namespace FloatingMenu.Controls
         {
             int expandedId = _isExpand ? 1 : 0;
 
-            foreach (var (child, index) in Children.Select((c,i)=>(c,i)).Skip(1 - expandedId).Take(Children.Count - expandedId))
-            {
-                _ = child.TranslateTo(0, -YAxis * (index + expandedId), (uint)time);
-            }
-            
-            await Task.Delay(time);
+            var tasks = Children.Select((c, i) => (c, i)).Skip(1 - expandedId).Take(Children.Count - expandedId)
+                .Select(tuple => tuple.c.TranslateTo(0, -YAxis * (tuple.i + expandedId), (uint)time)).ToList();
+            await Task.WhenAll(tasks);
 
             foreach (var child in Children.Skip(1 - expandedId).Take(Children.Count - expandedId))
             {


### PR DESCRIPTION
- I noticed that I could not cancel a expanding, and this was because of the way we `await`ed the collapsing.

- Rotation should be set from the consumer, and children should rotate to the inverted rotation value to always look good. ⭐️ 
